### PR TITLE
fix: handle estimate edge case

### DIFF
--- a/app/routes/rooms/$roomId.tsx
+++ b/app/routes/rooms/$roomId.tsx
@@ -129,6 +129,7 @@ export default function Room() {
     if (existingPlayer) {
       if (latestMessage.playerLeft || !!latestMessage.isSpectator) {
         removePlayer(latestMessage.userId);
+        return;
       }
 
       if (!!latestMessage.estimate) {
@@ -241,7 +242,7 @@ export default function Room() {
     const message = JSON.stringify({
       userId,
       roomId,
-      estimate: null,
+      estimate,
       isHidden,
       isSpectator: newValue,
     });


### PR DESCRIPTION
These changes fix an issue when a player votes, then designates they are a spectator, then designates they aren't a spectator.